### PR TITLE
Update gasfvf.py

### DIFF
--- a/Unit 2 Review of Rock and Fluid Properties/functions/gasfvf.py
+++ b/Unit 2 Review of Rock and Fluid Properties/functions/gasfvf.py
@@ -1,19 +1,15 @@
-def gasfvf(z, temp, pressure):
+def gasfvf(unit='cuft/scf', z, temp, pressure):
   """
-  Gas FVF calculated in oilfield unit, result in RB/scf
-  inputs temp in Rankine (Fahrenheit + 460), pressure in psia or psig
+  Gas FVF calculated in user specified unit
+  input: unit of choice (cuft/scf, rb/scf, rm3/stdm3), zfactor, temperature (deg Farenheit) and pressure (psia).
   """
-  Bg = 0.0282793 * z * temp / pressure 
-  return(Bg)
-
-def gasfvf2(unit='unit1', z=0.8, temp=186, pressure=2000):
-  """
-  Gas FVF calculated in other units
-  unit: choice of units (unit1: RB/scf, unit2: res m3/std m3)
-  for unit1, inputs temp in Rankine (Fahrenheit + 460), pressure in psia or psig
-  for unit2, inputs temp in Kelvin, pressure in psia or psig
-  """
-  if unit == 'unit1':
+  temp=temp+460
+  if unit == 'cuft/scf':
+    return (0.0282793 * z * temp / pressure)
+  elif unit == 'rb/scf':
     return(0.00503676 * z * temp / pressure) 
-  if unit == 'unit2':
+  elif unit == 'rm3/stdm3':
     return(0.350958 * z * temp / pressure)
+  else:
+    print ("Unit not recognized, kindly use the appropriate unit")
+    return None


### PR DESCRIPTION
There was an error with the unit for gasfvf function, unit should be reservoir cubic feet per standard cubic feet, not reservoir barrels.
Also, I merged both functions into one as I think its better for interfacing with users of the function. With respect to interfacing with users, I think it will be better to use strings that reservoir engineers are familiar with as the unit parameters.
Lastly, I added a form of validation to check for errors in unit input.